### PR TITLE
Push model updating out of controller

### DIFF
--- a/My Warcraft Addon Downloads.xcodeproj/project.pbxproj
+++ b/My Warcraft Addon Downloads.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		03672C991B609536007E51B9 /* My_Warcraft_Addon_DownloadsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03672C981B609536007E51B9 /* My_Warcraft_Addon_DownloadsTests.m */; };
 		03672CA61B6096DE007E51B9 /* Addon.m in Sources */ = {isa = PBXBuildFile; fileRef = 03672CA31B6096DE007E51B9 /* Addon.m */; };
 		03672CA71B6096DE007E51B9 /* AddonsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 03672CA51B6096DE007E51B9 /* AddonsTableViewController.m */; };
+		03672CB01B6340A4007E51B9 /* Addons.m in Sources */ = {isa = PBXBuildFile; fileRef = 03672CAF1B6340A4007E51B9 /* Addons.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,8 @@
 		03672CA31B6096DE007E51B9 /* Addon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Addon.m; sourceTree = "<group>"; };
 		03672CA41B6096DE007E51B9 /* AddonsTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddonsTableViewController.h; sourceTree = "<group>"; };
 		03672CA51B6096DE007E51B9 /* AddonsTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AddonsTableViewController.m; sourceTree = "<group>"; };
+		03672CAE1B6340A4007E51B9 /* Addons.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Addons.h; sourceTree = "<group>"; };
+		03672CAF1B6340A4007E51B9 /* Addons.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Addons.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +100,8 @@
 				03672C8B1B609535007E51B9 /* LaunchScreen.xib */,
 				03672C801B609535007E51B9 /* My_Warcraft_Addon_Downloads.xcdatamodeld */,
 				03672C791B609535007E51B9 /* Supporting Files */,
+				03672CAE1B6340A4007E51B9 /* Addons.h */,
+				03672CAF1B6340A4007E51B9 /* Addons.m */,
 			);
 			path = "My Warcraft Addon Downloads";
 			sourceTree = "<group>";
@@ -227,6 +232,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				03672CB01B6340A4007E51B9 /* Addons.m in Sources */,
 				03672C7F1B609535007E51B9 /* AppDelegate.m in Sources */,
 				03672CA61B6096DE007E51B9 /* Addon.m in Sources */,
 				03672CA71B6096DE007E51B9 /* AddonsTableViewController.m in Sources */,

--- a/My Warcraft Addon Downloads.xcodeproj/project.pbxproj
+++ b/My Warcraft Addon Downloads.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		03672CA51B6096DE007E51B9 /* AddonsTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AddonsTableViewController.m; sourceTree = "<group>"; };
 		03672CAE1B6340A4007E51B9 /* Addons.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Addons.h; sourceTree = "<group>"; };
 		03672CAF1B6340A4007E51B9 /* Addons.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Addons.m; sourceTree = "<group>"; };
+		03672CB11B641B24007E51B9 /* AddonsTableViewControllerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddonsTableViewControllerDelegate.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +103,7 @@
 				03672C791B609535007E51B9 /* Supporting Files */,
 				03672CAE1B6340A4007E51B9 /* Addons.h */,
 				03672CAF1B6340A4007E51B9 /* Addons.m */,
+				03672CB11B641B24007E51B9 /* AddonsTableViewControllerDelegate.h */,
 			);
 			path = "My Warcraft Addon Downloads";
 			sourceTree = "<group>";

--- a/My Warcraft Addon Downloads/Addons.h
+++ b/My Warcraft Addon Downloads/Addons.h
@@ -1,0 +1,18 @@
+//
+//  Addons.h
+//  My Warcraft Addon Downloads
+//
+//  Created by jhegg on 7/24/15.
+//  Copyright (c) 2015 Josh Hegg. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Addons : NSObject
+
+@property NSInteger count;
+
+- (NSArray *)allAddons;
+- (void)updateAddons:(void(^)(void))handler;
+
+@end

--- a/My Warcraft Addon Downloads/Addons.h
+++ b/My Warcraft Addon Downloads/Addons.h
@@ -7,10 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "AddonsTableViewControllerDelegate.h"
 
 @interface Addons : NSObject
 
 @property NSInteger count;
+@property id <AddonsTableViewControllerDelegate> delegate;
 
 - (NSArray *)allAddons;
 - (void)updateAddons:(void(^)(void))handler;

--- a/My Warcraft Addon Downloads/Addons.m
+++ b/My Warcraft Addon Downloads/Addons.m
@@ -105,6 +105,7 @@
     for (Addon *addon in _addons) {
         if ([addon.addonName isEqualToString:addonName]) {
             addon.addonTotalDownloads = count;
+            [self.delegate refreshTable];
             return;
         }
     }

--- a/My Warcraft Addon Downloads/Addons.m
+++ b/My Warcraft Addon Downloads/Addons.m
@@ -1,0 +1,121 @@
+//
+//  Addons.m
+//  My Warcraft Addon Downloads
+//
+//  Created by jhegg on 7/24/15.
+//  Copyright (c) 2015 Josh Hegg. All rights reserved.
+//
+
+#import "Addons.h"
+#import "Addon.h"
+
+@interface Addons ()
+@property NSMutableArray *addons;
+@end
+
+@implementation Addons
+
+- (id)init {
+    self = [super init];
+    _count = 0;    
+    _addons = [[NSMutableArray alloc] init];
+    return self;
+}
+
+- (void)updateAddons:(void(^)(void))handler {
+    NSURL *url = [NSURL URLWithString:@"https://boxing-marks-7365.herokuapp.com/addons"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    [NSURLConnection
+     sendAsynchronousRequest:request
+     queue:[NSOperationQueue mainQueue]
+     completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+         if (data.length > 0 && connectionError == nil) {
+             // TODO: better error handling, for example HTTP status code != 200
+             
+             [self updateTableFromJsonData:data];
+             
+             handler();
+         }
+     }];
+}
+
+- (void)updateTableFromJsonData:(NSData *)data {
+    NSDictionary *addonsFromJson = [NSJSONSerialization
+                                    JSONObjectWithData:data
+                                    options:0
+                                    error:NULL];
+    for (NSString *key in addonsFromJson) {
+        [self processAddonFromJson:key];
+    }
+}
+
+- (void)processAddonFromJson:(NSString *)addonName {
+    for (Addon *addon in self.addons) {
+        if ([addon.addonName isEqualToString:addonName]) {
+            [self updateAddon:addon];
+            return;
+        }
+    }
+    
+    [self createAddon:addonName];
+}
+
+- (void)createAddon:(NSString *)addonName {
+    Addon *addon = [[Addon alloc] init];
+    addon.addonName = addonName;
+    [self queryDownloadCountForAddon:addonName];
+    [self.addons addObject:addon];
+    self.count = self.addons.count;
+}
+
+- (void)updateAddon:(Addon *)addon {
+    [self queryDownloadCountForAddon:addon.addonName];
+}
+
+- (void)queryDownloadCountForAddon:(NSString *)addonName {
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://boxing-marks-7365.herokuapp.com/addons/%@/downloads", addonName]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    [NSURLConnection
+     sendAsynchronousRequest:request
+     queue:[NSOperationQueue mainQueue]
+     completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+         if (data.length > 0 && connectionError == nil) {
+             [self updateAddonDownloadCountFromJson:data addonName:addonName];
+         }
+     }];
+}
+
+- (void)updateAddonDownloadCountFromJson:(NSData *)data addonName:(NSString *)addonName {
+    NSDictionary *addonsFromJson = [NSJSONSerialization
+                                    JSONObjectWithData:data
+                                    options:0
+                                    error:NULL];
+    NSArray *downloads = [addonsFromJson valueForKey:@"downloads"];
+    NSArray *sortedCounts = [downloads sortedArrayUsingComparator:^(id obj1, id obj2) {
+        NSNumber *first = @([[obj1 objectForKey:@"count"] intValue]);
+        NSNumber *second = @([[obj2 objectForKey:@"count"] intValue]);
+        return [first compare:second];
+    }];
+    
+    NSNumber *maxCount = @([[[sortedCounts lastObject] objectForKey:@"count"] intValue]);
+    [self updateAddonDownloadCount:maxCount addonName:addonName];
+}
+
+- (void)updateAddonDownloadCount:(NSNumber *)count addonName:(NSString *)addonName {
+    for (Addon *addon in _addons) {
+        if ([addon.addonName isEqualToString:addonName]) {
+            addon.addonTotalDownloads = count;
+            return;
+        }
+    }
+}
+
+- (NSArray *)allAddons {
+    NSSortDescriptor *nameDescriptor = [[NSSortDescriptor alloc]
+                                        initWithKey:@"addonName"
+                                        ascending:YES
+                                        selector:@selector(localizedCaseInsensitiveCompare:)];
+    return [self.addons sortedArrayUsingDescriptors:[NSArray arrayWithObjects:nameDescriptor, nil]];
+}
+
+@end

--- a/My Warcraft Addon Downloads/AddonsTableViewController.h
+++ b/My Warcraft Addon Downloads/AddonsTableViewController.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "AddonsTableViewControllerDelegate.h"
 
-@interface AddonsTableViewController : UITableViewController
+@interface AddonsTableViewController : UITableViewController <AddonsTableViewControllerDelegate>
 
 @end

--- a/My Warcraft Addon Downloads/AddonsTableViewController.m
+++ b/My Warcraft Addon Downloads/AddonsTableViewController.m
@@ -13,15 +13,12 @@
 @interface AddonsTableViewController ()
 
 @property Addons *addons2;
-@property (nonatomic, strong) id addonsObserveToken;
 
 - (IBAction)refresh:(UIRefreshControl *)sender;
 
 @end
 
 @implementation AddonsTableViewController
-
-// TODO: register KVO for Addons changes
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -33,6 +30,8 @@
                   forControlEvents:UIControlEventValueChanged];
     
     self.addons2 = [[Addons alloc] init];
+    self.addons2.delegate = self;
+    
     [self refresh:self.refreshControl];
 }
 
@@ -45,6 +44,10 @@
         [self.tableView reloadData];
         handler();
     }];
+}
+
+- (void)refreshTable {
+    [self.tableView reloadData];
 }
 
 #pragma mark - Table view data source

--- a/My Warcraft Addon Downloads/AddonsTableViewControllerDelegate.h
+++ b/My Warcraft Addon Downloads/AddonsTableViewControllerDelegate.h
@@ -1,0 +1,15 @@
+//
+//  AddonsTableViewControllerDelegate.h
+//  My Warcraft Addon Downloads
+//
+//  Created by jhegg on 7/25/15.
+//  Copyright (c) 2015 Josh Hegg. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol AddonsTableViewControllerDelegate <NSObject>
+
+- (void)refreshTable;
+
+@end


### PR DESCRIPTION
This introduces a new `Addons` class, which is responsible for maintaining and updating the collection of `Addon` objects. It is now making the REST API calls, instead of the `AddonsTableViewController` class. I've also added the delegate pattern, so that when `Addons` finishes updating a piece of data, it can tell `AddonsTableViewController` to refresh the view using the new data. I tried to use a block at first, but I seemed to be mixing too many concerns. This appears to do what I want, for now, at least.
